### PR TITLE
Add HOT parameter sweep script for automated config evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ python tracking/analysis_results.py # need to modify tracker configs and names
 python tracking/evaluate_hot.py mcitrack mcitrack_b224
 ```
 
+### Automated HOT parameter sweep
+```
+python tracking/run_param_sweep.py
+```
+This script tests multiple inference configurations and logs metrics to `experiments/mcitrack/auto/sweep_log.csv`.
+
+
 ## Test FLOPs, Params and Speed
 ```
 python tracking/profile_model.py --script mcitrack --config mcitrack_b224


### PR DESCRIPTION
## Summary
- add `tracking/run_param_sweep.py` to iterate over search/template parameters, run `evaluate_hot.py`, and log metrics
- document parameter sweep usage in README

## Testing
- `python -m py_compile tracking/run_param_sweep.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0b6b075f88332a47ea83d0dce12d1