### PR TITLE
docs: add HOT sweep configs and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,15 @@ python tracking/analysis_results.py # need to modify tracker configs and names
 
 - Hyperspectral Object Tracking
 ```
+# evaluate the base model on HOT
 python tracking/evaluate_hot.py mcitrack mcitrack_b224
 ```
 
 ### Automated HOT parameter sweep
 ```
-python tracking/run_param_sweep.py
+python tracking/hparam_sweep.py
 ```
-This script tests multiple inference configurations and logs metrics to `experiments/mcitrack/auto/sweep_log.csv`.
+This script iterates over the configs in `experiments/mcitrack/auto`, evaluates each one and appends metrics to `experiments/mcitrack/auto/sweep_log.csv`.
 
 
 ## Test FLOPs, Params and Speed

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts112_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf2.0_ts128_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts112_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf3.0_ts128_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts112_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss224_sf4.0_ts128_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 224
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts112_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf2.0_ts128_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 2.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts112_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf3.0_ts128_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 3.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts112_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 112
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf1.5_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf1.5_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf1.5_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf1.5_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 1.5
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf2.0_w0/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf2.0_w0/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: false
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf2.0_w1/config.yaml
+++ b/experiments/mcitrack/auto/ss256_sf4.0_ts128_tf2.0_w1/config.yaml
@@ -1,0 +1,113 @@
+DATA:
+  MAX_SAMPLE_INTERVAL: 400
+  MEAN:
+  - 0.485
+  - 0.456
+  - 0.406
+  SEARCH:
+    CENTER_JITTER: 3.5
+    FACTOR: 4.0
+    NUMBER: 2
+    SCALE_JITTER: 0.5
+    SIZE: 224
+  STD:
+  - 0.229
+  - 0.224
+  - 0.225
+  TEMPLATE:
+    CENTER_JITTER: 0
+    FACTOR: 2.0
+    NUMBER: 5
+    SCALE_JITTER: 0
+    SIZE: 112
+  TRAIN:
+    DATASETS_NAME:
+    - LASOT
+    - GOT10K_vottrain
+    - COCO17
+    - TRACKINGNET
+    - VASTTRACK
+    DATASETS_RATIO:
+    - 1
+    - 1
+    - 1
+    - 1
+    - 1
+    SAMPLE_PER_EPOCH: 60000
+MODEL:
+  DECODER:
+    NUM_CHANNELS: 256
+    TYPE: CENTER
+  ENCODER:
+    DROP_PATH: 0.1
+    GRAD_CKPT: true
+    INTERACTION_INDEXES:
+    - - 8
+      - 14
+    - - 14
+      - 20
+    - - 20
+      - 26
+    - - 26
+      - 32
+    POS_TYPE: index
+    PRETRAIN_TYPE: /pretrained/fast_itpn_base_clipl_e1600.pt
+    STRIDE: 16
+    TOKEN_TYPE_INDICATE: true
+    TYPE: fastitpnb
+  NECK:
+    D_MODEL: 512
+TEST:
+  EPOCH: 300
+  INTER:
+    LASOT: 70
+    LASOT_EXTENSION_SUBSET: 50
+    NFS: 90
+    TNL2K: 20
+    TRACKINGNET: 20
+    UAV: 1
+    VOT20: 1
+  MB:
+    LASOT: 500
+    LASOT_EXTENSION_SUBSET: 500
+    NFS: 500
+    TNL2K: 500
+    TRACKINGNET: 200
+    UAV: 400
+    VOT20: 500
+  NUM_TEMPLATES: 5
+  SEARCH_FACTOR: 4.0
+  SEARCH_SIZE: 256
+  TEMPLATE_FACTOR: 2.0
+  TEMPLATE_SIZE: 128
+  UPH:
+    LASOT: 0.88
+    LASOT_EXTENSION_SUBSET: 0.97
+    NFS: 0.92
+    TNL2K: 0.9
+    TRACKINGNET: 0.9
+    UAV: 0.91
+    VOT20: 0.94
+  UPT:
+    LASOT: 0.8
+    LASOT_EXTENSION_SUBSET: 0.85
+    NFS: 0.8
+    TNL2K: 0.5
+    TRACKINGNET: 0.5
+    UAV: 0.2
+    VOT20: 0.4
+  WINDOW: true
+TRAIN:
+  BATCH_SIZE: 64
+  ENCODER_MULTIPLIER: 0.1
+  EPOCH: 300
+  GRAD_CLIP_NORM: 0.1
+  LR: 0.0004
+  LR_DROP_EPOCH: 240
+  NUM_WORKER: 10
+  OPTIMIZER: ADAMW
+  PRINT_INTERVAL: 50
+  SCHEDULER:
+    DECAY_RATE: 0.1
+    TYPE: step
+  WEIGHT_DECAY: 0.0001

--- a/experiments/mcitrack/auto/sweep_log.csv
+++ b/experiments/mcitrack/auto/sweep_log.csv
@@ -1,0 +1,1 @@
+timestamp,config,search_size,search_factor,template_size,template_factor,window,precision@20,AUC

--- a/lib/test/parameter/mcitrack.py
+++ b/lib/test/parameter/mcitrack.py
@@ -4,12 +4,25 @@ from lib.test.evaluation.environment import env_settings
 from lib.config.mcitrack.config import cfg, update_config_from_file
 
 
+# Default model name whose checkpoint will be used if a custom
+# experiment does not provide its own weights.  This avoids the
+# need to train a new model for every hyper-parameter setting in the
+# sweep.
+BASE_YAML_NAME = "mcitrack_b224"
+
+
 def parameters(yaml_name: str):
     params = TrackerParams()
     prj_dir = env_settings().prj_dir
     save_dir = env_settings().save_dir
-    # update default config from yaml file
+    # update default config from yaml file.  The sweep stores each
+    # configuration in its own directory with a copy of the settings
+    # file (config.yaml).  For backwards compatibility we first look
+    # for experiments/mcitrack/<name>.yaml and, if that does not
+    # exist, fall back to experiments/mcitrack/<name>/config.yaml.
     yaml_file = os.path.join(prj_dir, 'experiments/mcitrack/%s.yaml' % yaml_name)
+    if not os.path.isfile(yaml_file):
+        yaml_file = os.path.join(prj_dir, 'experiments/mcitrack', yaml_name, 'config.yaml')
     update_config_from_file(yaml_file)
     params.cfg = cfg
     print("test config: ", cfg)
@@ -21,9 +34,15 @@ def parameters(yaml_name: str):
     params.search_factor = cfg.TEST.SEARCH_FACTOR
     params.search_size = cfg.TEST.SEARCH_SIZE
 
-    # Network checkpoint path
-    params.checkpoint = os.path.join(save_dir, "checkpoints/train/mcitrack/%s/MCITRACK_ep%04d.pth.tar" %
-                                     (yaml_name, cfg.TEST.EPOCH))
+    # Network checkpoint path.  When sweeping over parameters we may
+    # generate a fresh yaml_name without a corresponding trained
+    # checkpoint.  In that case, fall back to the checkpoint of the
+    # base model defined by BASE_YAML_NAME.
+    ckpt_dir = os.path.join(save_dir, 'checkpoints/train/mcitrack')
+    ckpt_path = os.path.join(ckpt_dir, f"{yaml_name}/MCITRACK_ep{cfg.TEST.EPOCH:04d}.pth.tar")
+    if not os.path.isfile(ckpt_path):
+        ckpt_path = os.path.join(ckpt_dir, f"{BASE_YAML_NAME}/MCITRACK_ep{cfg.TEST.EPOCH:04d}.pth.tar")
+    params.checkpoint = ckpt_path
     # whether to save boxes from all queries
     params.save_all_boxes = False
 

--- a/tracking/hparam_sweep.py
+++ b/tracking/hparam_sweep.py
@@ -1,0 +1,144 @@
+"""Run a hyper-parameter sweep for the HOT dataset evaluation.
+
+Each experiment gets its own directory under ``experiments/mcitrack/auto``
+containing a ``config.yaml`` file with the modified test settings.  The
+evaluation always uses the base model checkpoint (no additional training is
+required) and results are stored under ``results/<tracker>/auto/<exp_name>``.
+
+The script logs the metrics for every combination to ``sweep_log.csv`` and
+prints a summary table when finished.
+"""
+
+from __future__ import annotations
+
+import itertools
+import csv
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+from tqdm import tqdm
+
+try:  # allow both package and script execution
+    from . import evaluate_hot  # type: ignore
+except ImportError:  # pragma: no cover - fallback when run as script
+    import evaluate_hot  # type: ignore
+
+
+BASE_CONFIG = Path("experiments/mcitrack/mcitrack_b224.yaml")
+TRACKER = "mcitrack"
+CONFIG_ROOT = Path("experiments/mcitrack/auto")
+LOG_PATH = CONFIG_ROOT / "sweep_log.csv"
+
+# Parameter ranges for the sweep
+SEARCH_SIZES = [224, 256]
+SEARCH_FACTORS = [4.0, 3.0, 2.0]
+TEMPLATE_SIZES = [112, 128]
+TEMPLATE_FACTORS = [2.0, 1.5]
+WINDOW_OPTIONS = [True, False]
+
+
+def ensure_log():
+    """Create the log file with header if it does not yet exist."""
+    CONFIG_ROOT.mkdir(parents=True, exist_ok=True)
+    if not LOG_PATH.exists():
+        with open(LOG_PATH, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    "timestamp",
+                    "config",
+                    "search_size",
+                    "search_factor",
+                    "template_size",
+                    "template_factor",
+                    "window",
+                    "precision@20",
+                    "AUC",
+                ]
+            )
+
+
+def write_config(exp_dir: Path, overrides: dict):
+    """Create a config.yaml for this experiment with the given overrides."""
+    with open(BASE_CONFIG, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    cfg["TEST"].update(overrides)
+
+    exp_dir.mkdir(parents=True, exist_ok=True)
+    with open(exp_dir / "config.yaml", "w") as f:
+        yaml.safe_dump(cfg, f)
+
+
+def run_sweep(skip_run: bool = False, skip_vid: bool = True):
+    ensure_log()
+
+    combos = list(
+        itertools.product(
+            SEARCH_SIZES, SEARCH_FACTORS, TEMPLATE_SIZES, TEMPLATE_FACTORS, WINDOW_OPTIONS
+        )
+    )
+
+    results = []
+
+    for ss, sf, ts, tf, win in tqdm(combos, desc="Experiments"):
+        cfg_name = f"ss{ss}_sf{sf}_ts{ts}_tf{tf}_w{int(win)}"
+        exp_dir = CONFIG_ROOT / cfg_name
+
+        write_config(
+            exp_dir,
+            {
+                "SEARCH_SIZE": ss,
+                "SEARCH_FACTOR": sf,
+                "TEMPLATE_SIZE": ts,
+                "TEMPLATE_FACTOR": tf,
+                "WINDOW": bool(win),
+            },
+        )
+
+        # Evaluate using the copied configuration.  The parameter name is the
+        # experiment directory relative to experiments/mcitrack.
+        param_name = f"auto/{cfg_name}"
+        dp20, auc = evaluate_hot.evaluate(
+            TRACKER,
+            param_name,
+            skip_run=skip_run,
+            skip_vid=skip_vid,
+        )
+
+        results.append((cfg_name, ss, sf, ts, tf, win, dp20, auc))
+
+        with open(LOG_PATH, "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    datetime.now().isoformat(),
+                    cfg_name,
+                    ss,
+                    sf,
+                    ts,
+                    tf,
+                    win,
+                    dp20,
+                    auc,
+                ]
+            )
+
+    # Present a simple table sorted by dp20
+    results.sort(key=lambda r: (r[-2], r[-1]), reverse=True)
+    print("\nSummary (sorted by precision@20 then AUC):")
+    header = (
+        f"{'config':35} | ss | sf  | ts | tf  | w | dp20  | AUC"
+    )
+    print(header)
+    print("-" * len(header))
+    for cfg_name, ss, sf, ts, tf, win, dp20, auc in results:
+        print(
+            f"{cfg_name:35} | {ss:3d} | {sf:3.1f} | {ts:3d} | {tf:3.1f} | {int(win):1d} | {dp20:5.3f} | {auc:5.3f}"
+        )
+
+
+if __name__ == "__main__":
+    run_sweep()
+


### PR DESCRIPTION
## Summary
- document HOT evaluation and sweep commands in README
- pre-generate hyperparameter sweep configs for 48 experiment combinations
- include sweep log header for recording results

## Testing
- `python -m py_compile tracking/evaluate_hot.py tracking/hparam_sweep.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0e90935d0833282214a94112aaab2