### PR TITLE
Ensure HOT parameter sweep runs on GPU

### DIFF
--- a/tracking/hparam_sweep.py
+++ b/tracking/hparam_sweep.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import yaml
 from tqdm import tqdm
+import torch
 
 try:  # allow both package and script execution
     from . import evaluate_hot  # type: ignore
@@ -74,6 +75,10 @@ def write_config(exp_dir: Path, overrides: dict):
 def run_sweep(skip_run: bool = False, skip_vid: bool = True):
     ensure_log()
 
+    num_gpus = torch.cuda.device_count()
+    if num_gpus == 0:
+        raise RuntimeError("No CUDA devices available for the hyper-parameter sweep.")
+
     combos = list(
         itertools.product(
             SEARCH_SIZES, SEARCH_FACTORS, TEMPLATE_SIZES, TEMPLATE_FACTORS, WINDOW_OPTIONS
@@ -105,6 +110,7 @@ def run_sweep(skip_run: bool = False, skip_vid: bool = True):
             param_name,
             skip_run=skip_run,
             skip_vid=skip_vid,
+            num_gpus=num_gpus,
         )
 
         results.append((cfg_name, ss, sf, ts, tf, win, dp20, auc))


### PR DESCRIPTION
## Summary
- Detect available CUDA devices before running HOT hyper-parameter sweep
- Pass detected GPU count to evaluation to ensure tracker runs on GPU

## Testing
- `python -m py_compile tracking/hparam_sweep.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1d63ef83c8332b5ea088d70d9e402