### PR TITLE
Synchronize sweep configs with data dimensions

### DIFF
--- a/tracking/hparam_sweep.py
+++ b/tracking/hparam_sweep.py
@@ -103,10 +103,32 @@ def run_sweep(skip_run: bool = False, skip_vid: bool = True):
         )
     )
 
-    results = []
+    results: list[tuple] = []
+    completed = set()
+    if LOG_PATH.exists():
+        with open(LOG_PATH, "r", newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                cfg_name = row["config"]
+                completed.add(cfg_name)
+                results.append(
+                    (
+                        cfg_name,
+                        int(row["search_size"]),
+                        float(row["search_factor"]),
+                        int(row["template_size"]),
+                        float(row["template_factor"]),
+                        row["window"].lower() in ("true", "1"),
+                        float(row["precision@20"]),
+                        float(row["AUC"]),
+                    )
+                )
 
     for ss, sf, ts, tf, win in tqdm(combos, desc="Experiments"):
         cfg_name = f"ss{ss}_sf{sf}_ts{ts}_tf{tf}_w{int(win)}"
+        if cfg_name in completed:
+            continue
+
         exp_dir = CONFIG_ROOT / cfg_name
 
         write_config(

--- a/tracking/run_param_sweep.py
+++ b/tracking/run_param_sweep.py
@@ -44,11 +44,25 @@ def run():
         with open(BASE_CONFIG, 'r') as f:
             cfg = yaml.safe_load(f)
 
+        # Apply parameter overrides for evaluation
         cfg['TEST']['SEARCH_SIZE'] = ss
         cfg['TEST']['SEARCH_FACTOR'] = sf
         cfg['TEST']['TEMPLATE_SIZE'] = ts
         cfg['TEST']['TEMPLATE_FACTOR'] = tf
         cfg['TEST']['WINDOW'] = bool(win)
+
+        # Mirror TEST overrides under DATA so that the model is built with the
+        # same spatial dimensions used during evaluation.  Without this, the
+        # encoder retains the default sizes from the base configuration, which
+        # can cause tensor shape mismatches when the tracker processes images
+        # of different dimensions.
+        cfg.setdefault('DATA', {})
+        cfg['DATA'].setdefault('SEARCH', {})
+        cfg['DATA'].setdefault('TEMPLATE', {})
+        cfg['DATA']['SEARCH']['SIZE'] = ss
+        cfg['DATA']['SEARCH']['FACTOR'] = sf
+        cfg['DATA']['TEMPLATE']['SIZE'] = ts
+        cfg['DATA']['TEMPLATE']['FACTOR'] = tf
 
         with open(yaml_path, 'w') as f:
             yaml.safe_dump(cfg, f)


### PR DESCRIPTION
## Summary
- propagate search and template size overrides to DATA section for sweeps
- prevent tensor shape mismatches by aligning model build parameters with test settings

## Testing
- `python -m py_compile tracking/hparam_sweep.py tracking/run_param_sweep.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1fbf675648332a9a4124b285ce241