### PR TITLE
Improve tracking run feedback

### DIFF
--- a/lib/test/evaluation/running.py
+++ b/lib/test/evaluation/running.py
@@ -6,6 +6,7 @@ from itertools import product
 from collections import OrderedDict
 from lib.test.evaluation import Sequence, Tracker
 import torch
+import traceback
 
 
 def _save_tracker_output(seq: Sequence, tracker: Tracker, output: dict):
@@ -135,8 +136,9 @@ def run_sequence(seq: Sequence, tracker: Tracker, debug=False, num_gpu=8):
         try:
             output = tracker.run_sequence(seq, debug=debug)
         except Exception as e:
-            print(e)
-            return
+            print(f"Error while running {tracker.name} on {seq.name}: {e}")
+            traceback.print_exc()
+            raise
 
     sys.stdout.flush()
 

--- a/lib/test/evaluation/tracker.py
+++ b/lib/test/evaluation/tracker.py
@@ -9,6 +9,7 @@ import sys
 from lib.utils.lmdb_utils import decode_img
 from pathlib import Path
 import numpy as np
+from tqdm import tqdm
 
 
 def trackerlist(name: str, parameter_name: str, dataset_name: str, run_ids = None, display_name: str = None,
@@ -132,7 +133,8 @@ class Tracker:
 
         _store_outputs(out, init_default)
 
-        for frame_num, frame_path in enumerate(seq.frames[1:], start=1):
+        for frame_num, frame_path in enumerate(
+                tqdm(seq.frames[1:], desc=f"{seq.name}", unit="frame"), start=1):
             image = self._read_image(frame_path)
 
             start_time = time.time()

--- a/lib/test/parameter/mcitrack.py
+++ b/lib/test/parameter/mcitrack.py
@@ -25,7 +25,6 @@ def parameters(yaml_name: str):
         yaml_file = os.path.join(prj_dir, 'experiments/mcitrack', yaml_name, 'config.yaml')
     update_config_from_file(yaml_file)
     params.cfg = cfg
-    print("test config: ", cfg)
 
     params.yaml_name = yaml_name
     # template and search region


### PR DESCRIPTION
## Summary
- Remove noisy test configuration dump in mcitrack parameter loader
- Surface full stack traces for sequence failures and re-raise exceptions
- Display per-frame progress with tqdm during tracking runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b20c3cc7e88332bdf669af23ca675a