### PR TITLE
chore: update timm import paths

### DIFF
--- a/lib/models/mcitrack/fastitpn.py
+++ b/lib/models/mcitrack/fastitpn.py
@@ -14,10 +14,10 @@ import warnings
 import math
 import torch
 import torch.nn as nn
-from timm.models.registry import register_model
+from timm.models import register_model
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
-from timm.models.layers import to_2tuple, drop_path, trunc_normal_
+from timm.layers import to_2tuple, drop_path, trunc_normal_
 
 from torch import Tensor, Size
 from typing import Union, List

--- a/lib/models/mcitrack/neck.py
+++ b/lib/models/mcitrack/neck.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from functools import partial
-from timm.models.layers import DropPath
+from timm.layers import DropPath
 import torch.utils.checkpoint as checkpoint
 class DWConv(nn.Module):
     def __init__(self, dim=768):


### PR DESCRIPTION
## Summary
- update timm registry import to new API
- use `timm.layers` instead of `timm.models.layers`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b215b7578883329515631740a0c9bc