### PR TITLE
Handle full model checkpoints without positional interpolation

### DIFF
--- a/lib/test/tracker/mcitrack.py
+++ b/lib/test/tracker/mcitrack.py
@@ -17,7 +17,12 @@ class MCITRACK(BaseTracker):
         super(MCITRACK, self).__init__(params)
         network = build_mcitrack(params.cfg)
         checkpoint = torch.load(self.params.checkpoint, map_location="cpu")['net']
-        load_pretrained(network, checkpoint, params.cfg.MODEL.ENCODER.POS_TYPE)
+        model_state = network.state_dict()
+        pos_key = next((k for k in model_state.keys() if 'pos_embed' in k), None)
+        if pos_key and pos_key in checkpoint and checkpoint[pos_key].shape == model_state[pos_key].shape:
+            network.load_state_dict(checkpoint)
+        else:
+            load_pretrained(network, checkpoint, params.cfg.MODEL.ENCODER.POS_TYPE)
         self.cfg = params.cfg
         self.network = network.cuda()
         self.network.eval()


### PR DESCRIPTION
## Summary
- Load checkpoint directly with `load_state_dict` when weights already match the full model
- Fall back to `load_pretrained` for backbone-only checkpoints that require positional embedding interpolation

## Testing
- `python -m py_compile lib/test/tracker/mcitrack.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b216bcac8c8332bdc115ee0e33f4b7