### PR TITLE
Support num-template sweep and robust pos-embed loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ python tracking/evaluate_hot.py mcitrack mcitrack_b224
 ```
 python tracking/hparam_sweep.py
 ```
-This script iterates over the configs in `experiments/mcitrack/auto`, evaluates each one and appends metrics to `experiments/mcitrack/auto/sweep_log.csv`.
+This script iterates over combinations of search/template sizes and factors, the window option, and the number of templates.  Each configuration under `experiments/mcitrack/auto` is evaluated and the metrics are appended to `experiments/mcitrack/auto/sweep_log.csv`.
 
 
 ## Test FLOPs, Params and Speed


### PR DESCRIPTION
## Summary
- allow `load_pretrained` to find positional embeddings under any prefix
- expand parameter sweep scripts to include number of templates
- document new sweep options

## Testing
- `python -m py_compile lib/models/mcitrack/fastitpn.py tracking/hparam_sweep.py tracking/run_param_sweep.py`


------
https://chatgpt.com/codex/tasks/task_e_68b218fe86608332a7b1780776752534