### PR TITLE
Handle unannotated HOT sequences and simplify prediction CSV IDs

### DIFF
--- a/lib/test/evaluation/running.py
+++ b/lib/test/evaluation/running.py
@@ -149,7 +149,8 @@ def run_sequence(seq: Sequence, tracker: Tracker, debug=False, num_gpu=8):
         exec_time = sum(output['time'])
         num_frames = len(output['time'])
 
-    print('FPS: {}'.format(num_frames / exec_time))
+    fps = float('inf') if exec_time == 0 else num_frames / exec_time
+    print('FPS: {}'.format(fps))
 
     if not debug:
         _save_tracker_output(seq, tracker, output)

--- a/tracking/predict_to_csv.py
+++ b/tracking/predict_to_csv.py
@@ -96,8 +96,6 @@ def main():
                         help='Path to the single output CSV (default: submission.csv)')
     parser.add_argument('--sequence', type=str, default=None,
                         help='Optional single sequence name to run/aggregate')
-    parser.add_argument('--prefix', type=str, default='vis',
-                        help='ID prefix (e.g., vis -> vis-<sequence>_<idx>)')
     parser.add_argument('--start_index', type=int, default=1,
                         help='Frame index base for IDs (1 for _1, 0 for _0, ...)')
     parser.add_argument('--init_rect_filename', type=str, default='init_rect.txt',
@@ -130,7 +128,7 @@ def main():
     results_root = tracker.results_dir
 
     # Aggregate all predictions into a single CSV
-    # Format: id,x,y,w,h  with id like "<prefix>-<sequence>_<frame_idx>"
+    # Format: id,x,y,w,h  with id like "<sequence>_<frame_idx>"
     rows = []
     for seq in tqdm(dataset, desc="Collecting predictions"):
         base_path = find_pred_base(results_root, seq.name)
@@ -144,7 +142,7 @@ def main():
         # build IDs
         for i in range(n_frames):
             idx = i + args.start_index
-            id_str = f"{args.prefix}-{seq.name}_{idx}"
+            id_str = f"{seq.name}_{idx}"
             x, y, w, h = preds[i].tolist()
             rows.append((id_str, x, y, w, h))
 


### PR DESCRIPTION
## Summary
- Keep full frame lists when HOT sequences have only a single annotation and replicate the init box
- Guard FPS reporting against divide-by-zero in evaluation
- Drop prefix option in predict_to_csv so IDs use folder names directly

## Testing
- `python -m pytest`
- `PYTHONPATH=$PWD python tracking/predict_to_csv.py mcitrack mcitrack_l384 --skip_run` *(fails: YOU HAVE NOT SETUP YOUR local.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b54fd401a08332b8697955b87bc60a