### PR TITLE
Fix ToTensor mask transform and simplify single-GPU training

### DIFF
--- a/HOT_README.md
+++ b/HOT_README.md
@@ -43,7 +43,7 @@ settings.hot_dir = '/path/to/HOT_ROOT'
 Then use the HOT-specific experiment configuration:
 
 ```bash
-torchrun --nproc_per_node 1 lib/train/run_training.py --script mcitrack --config mcitrack_b224_hot --save_dir .
+python lib/train/run_training.py --script mcitrack --config mcitrack_b224_hot --save_dir .
 ```
 
 This trains MCITrack using only the HOT sequences.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ lib/test/evaluation/local.py  # paths about testing
 Download [pre-trained weights](https://drive.google.com/drive/folders/1qDAMcU3JpahV7MriEOl4KfjKvAAFXd3E?usp=sharing) and put it under [./pretrained](pretrained)
 ### Train MCITrack
 ```
-torchrun --nproc_per_node 8 lib/train/run_training.py --script mcitrack --config mcitrack_b224 --save_dir .
+python lib/train/run_training.py --script mcitrack --config mcitrack_b224 --save_dir .
 ```
 
 ### Fine-tune or retrain
@@ -127,7 +127,7 @@ To train exclusively on your HOT dataset, first set `hot_dir` in
 HOT-specific config:
 
 ```
-torchrun --nproc_per_node 1 lib/train/run_training.py --script mcitrack --config mcitrack_b224_hot --save_dir .
+python lib/train/run_training.py --script mcitrack --config mcitrack_b224_hot --save_dir .
 ```
 
 This configuration uses only the HOT sequences and a small batch size suitable

--- a/lib/train/data/transforms.py
+++ b/lib/train/data/transforms.py
@@ -193,9 +193,14 @@ class ToTensor(TransformBase):
         else:
             return image
 
-    def transfrom_mask(self, mask):
+    def transform_mask(self, mask):
+        """Convert mask to a tensor."""
         if isinstance(mask, np.ndarray):
             return torch.from_numpy(mask)
+        elif isinstance(mask, torch.Tensor):
+            return mask
+        else:
+            raise ValueError("dtype must be np.ndarray or torch.Tensor")
 
     def transform_att(self, att):
         if isinstance(att, np.ndarray):

--- a/lib/train/run_training.py
+++ b/lib/train/run_training.py
@@ -1,6 +1,6 @@
 import os
-local_rank = os.environ['LOCAL_RANK']
-# local_rank = -1
+# Default to single-GPU mode when LOCAL_RANK is not set
+local_rank = int(os.environ.get('LOCAL_RANK', -1))
 import sys
 import argparse
 import importlib
@@ -100,7 +100,7 @@ def main():
         dist.init_process_group(backend='nccl')
         torch.cuda.set_device(int(local_rank))
     else:
-        torch.cuda.set_device(1)
+        torch.cuda.set_device(0)
     run_training(args.script, args.config, cudnn_benchmark=args.cudnn_benchmark,
                  local_rank= int(local_rank), save_dir=args.save_dir, base_seed=args.seed,
                  use_lmdb=args.use_lmdb, script_name_prv=args.script_prv, config_name_prv=args.config_prv,


### PR DESCRIPTION
## Summary
- Correct ToTensor's mask handling to always return a tensor
- Default training script to single-GPU when LOCAL_RANK is unset and update docs
- Replace torchrun commands with direct Python invocation for single GPU setups

## Testing
- `python -m py_compile lib/train/data/transforms.py lib/train/run_training.py`
- `python lib/train/run_training.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b5edbdebac8332901c8ffb367518b8