### PR TITLE
Fix DataLoader compatibility with Python 3.10+

### DIFF
--- a/lib/train/data/loader.py
+++ b/lib/train/data/loader.py
@@ -1,7 +1,9 @@
 import torch
 import torch.utils.data.dataloader
 import importlib
-import collections
+# collections.abc provides abstract base classes like Mapping and Sequence
+# which replaced their counterparts in the collections module in Python 3.10+
+from collections.abc import Mapping, Sequence
 # from torch._six import string_classes
 string_classes = str
 int_classes = int
@@ -54,12 +56,12 @@ def ltr_collate(batch):
         return batch
     elif isinstance(batch[0], TensorDict):
         return TensorDict({key: ltr_collate([d[key] for d in batch]) for key in batch[0]})
-    elif isinstance(batch[0], collections.Mapping):
+    elif isinstance(batch[0], Mapping):
         return {key: ltr_collate([d[key] for d in batch]) for key in batch[0]}
     elif isinstance(batch[0], TensorList):
         transposed = zip(*batch)
         return TensorList([ltr_collate(samples) for samples in transposed])
-    elif isinstance(batch[0], collections.Sequence):
+    elif isinstance(batch[0], Sequence):
         transposed = zip(*batch)
         return [ltr_collate(samples) for samples in transposed]
     elif batch[0] is None:
@@ -113,12 +115,12 @@ def ltr_collate_stack1(batch):
         return batch
     elif isinstance(batch[0], TensorDict):
         return TensorDict({key: ltr_collate_stack1([d[key] for d in batch]) for key in batch[0]})
-    elif isinstance(batch[0], collections.Mapping):
+    elif isinstance(batch[0], Mapping):
         return {key: ltr_collate_stack1([d[key] for d in batch]) for key in batch[0]}
     elif isinstance(batch[0], TensorList):
         transposed = zip(*batch)
         return TensorList([ltr_collate_stack1(samples) for samples in transposed])
-    elif isinstance(batch[0], collections.Sequence):
+    elif isinstance(batch[0], Sequence):
         transposed = zip(*batch)
         return [ltr_collate_stack1(samples) for samples in transposed]
     elif batch[0] is None:


### PR DESCRIPTION
## Summary
- replace deprecated `collections.Mapping`/`Sequence` with `collections.abc` equivalents in loader
- add clarification comments about Python 3.10+ changes

## Testing
- `pytest -q`
- `python - <<'PY'
from importlib.machinery import SourceFileLoader
loader_module = SourceFileLoader('loader_only', 'lib/train/data/loader.py').load_module()
print(loader_module.ltr_collate([{'a':1}, {'a':2}]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b6ab354c8c8332a04751a8955ee03b