### PR TITLE
Ensure TensorBoard logs flush

### DIFF
--- a/lib/train/admin/tensorboard.py
+++ b/lib/train/admin/tensorboard.py
@@ -25,3 +25,5 @@ class TensorboardWriter:
             for var_name, val in loader_stats.items():
                 if hasattr(val, 'history') and getattr(val, 'has_new_data', True):
                     self.writer[loader_name].add_scalar(var_name, val.history[ind], epoch)
+            # Flush to ensure TensorBoard reads the latest values
+            self.writer[loader_name].flush()


### PR DESCRIPTION
## Summary
- flush TensorBoard writers after each epoch so logs are written immediately

## Testing
- `python -m py_compile lib/train/admin/tensorboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b20bee848332be91891574c38edd