### PR TITLE
Log training stats to TensorBoard more frequently

### DIFF
--- a/lib/train/admin/tensorboard.py
+++ b/lib/train/admin/tensorboard.py
@@ -27,3 +27,22 @@ class TensorboardWriter:
                     self.writer[loader_name].add_scalar(var_name, val.history[ind], epoch)
             # Flush to ensure TensorBoard reads the latest values
             self.writer[loader_name].flush()
+
+    def write_interval(self, loader_name: str, stats: OrderedDict, step: int):
+        """Write current average stats to TensorBoard at a given step.
+
+        Args:
+            loader_name: Name of the dataloader whose stats should be written.
+            stats: OrderedDict mapping loader names to their statistics.
+            step: Global step (e.g. iteration number) for TensorBoard.
+        """
+        loader_stats = stats.get(loader_name, None)
+        if loader_stats is None:
+            return
+
+        for var_name, val in loader_stats.items():
+            if hasattr(val, 'avg'):
+                self.writer[loader_name].add_scalar(var_name, val.avg, step)
+
+        # Flush to ensure TensorBoard reads the latest values
+        self.writer[loader_name].flush()

--- a/lib/train/trainers/ltr_trainer.py
+++ b/lib/train/trainers/ltr_trainer.py
@@ -150,6 +150,10 @@ class LTRTrainer(BaseTrainer):
                 with open(self.settings.log_file, 'a') as f:
                     f.write(log_str)
 
+            if self.settings.local_rank in [-1, 0]:
+                global_step = (self.epoch - 1) * loader.__len__() + i
+                self.tensorboard_writer.write_interval(loader.name, self.stats, global_step)
+
     def _stats_new_epoch(self):
         # Record learning rate
         for loader in self.loaders:


### PR DESCRIPTION
## Summary
- Write training statistics to TensorBoard each print interval instead of only at epoch end
- Add `write_interval` helper to TensorboardWriter

## Testing
- `python -m py_compile lib/train/admin/tensorboard.py lib/train/trainers/ltr_trainer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb545d9c388332a763b70513304d93